### PR TITLE
Add initial backend test suite

### DIFF
--- a/backend/src/test/java/lsgwr/exam/controller/UserControllerTest.java
+++ b/backend/src/test/java/lsgwr/exam/controller/UserControllerTest.java
@@ -1,0 +1,49 @@
+package lsgwr.exam.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lsgwr.exam.qo.LoginQo;
+import lsgwr.exam.service.UserService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testLoginSuccess() throws Exception {
+        LoginQo qo = new LoginQo();
+        qo.setLoginType(1);
+        qo.setUserInfo("testuser");
+        qo.setPassword("pwd");
+
+        when(userService.login(any(LoginQo.class))).thenReturn("mock-token");
+
+        mockMvc.perform(post("/api/user/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(qo)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data").value("mock-token"));
+    }
+}

--- a/backend/src/test/java/lsgwr/exam/performance/JwtUtilsPerformanceTest.java
+++ b/backend/src/test/java/lsgwr/exam/performance/JwtUtilsPerformanceTest.java
@@ -1,0 +1,25 @@
+package lsgwr.exam.performance;
+
+import lsgwr.exam.entity.User;
+import lsgwr.exam.utils.JwtUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class JwtUtilsPerformanceTest {
+
+    @Test
+    public void testTokenGenerationPerformance() {
+        User user = new User();
+        user.setUserId("1");
+        user.setUserUsername("perfuser");
+        user.setUserAvatar("avatar.png");
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 1000; i++) {
+            String token = JwtUtils.genJsonWebToken(user);
+            assertNotNull(token);
+        }
+        long end = System.currentTimeMillis();
+        System.out.println("Generate 1000 tokens cost " + (end - start) + " ms");
+    }
+}

--- a/backend/src/test/java/lsgwr/exam/service/ExamServiceImplTest.java
+++ b/backend/src/test/java/lsgwr/exam/service/ExamServiceImplTest.java
@@ -1,0 +1,19 @@
+package lsgwr.exam.service.impl;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ExamServiceImplTest {
+
+    @Test
+    public void testTrimMiddleLineRemovesTrailingDash() {
+        String result = ExamServiceImpl.trimMiddleLine("1-2-3-");
+        assertEquals("1-2-3", result);
+    }
+
+    @Test
+    public void testTrimMiddleLineReturnsOriginalWhenNoTrailingDash() {
+        String result = ExamServiceImpl.trimMiddleLine("1-2-3");
+        assertEquals("1-2-3", result);
+    }
+}

--- a/backend/src/test/java/lsgwr/exam/utils/JwtUtilsTest.java
+++ b/backend/src/test/java/lsgwr/exam/utils/JwtUtilsTest.java
@@ -1,0 +1,25 @@
+package lsgwr.exam.utils;
+
+import io.jsonwebtoken.Claims;
+import lsgwr.exam.entity.User;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class JwtUtilsTest {
+    @Test
+    public void testGenerateAndCheckToken() {
+        User user = new User();
+        user.setUserId("1");
+        user.setUserUsername("testuser");
+        user.setUserAvatar("avatar.png");
+
+        String token = JwtUtils.genJsonWebToken(user);
+        assertNotNull(token);
+
+        Claims claims = JwtUtils.checkJWT(token);
+        assertNotNull(claims);
+        assertEquals("1", claims.get("id"));
+        assertEquals("testuser", claims.get("username"));
+        assertEquals("avatar.png", claims.get("avatar"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `JwtUtils`
- add unit test for `ExamServiceImpl.trimMiddleLine`
- add functional test for `UserController` login
- add simple performance test for token generation

## Testing
- `mvn -f backend/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a1a7445c83259e3f34aaf1f8540a